### PR TITLE
Using QProperty as data item

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ set(SRC
 	graphicsnodeview.cpp
 	graphicsnodescene.cpp
 	graphicsnodesocket.cpp
+
+        qobjectnode.cpp
+        test_qobjects.cpp
 	)
 set(HEADERS
 	mainwindow.hpp
@@ -40,6 +43,9 @@ set(HEADERS
 	graphicsnodescene.hpp
 	graphicsnodesocket.hpp
 	graphicsnodedefs.hpp
+
+        qobjectnode.hpp
+        test_qobjects.hpp
 )
 
 # include(${QT_USE_FILE})
@@ -49,7 +55,6 @@ include_directories(
 	)
 add_executable(${PROJECT_NAME} ${SRC} ${HEADERS_MOC} ${HEADERS})
 target_link_libraries(${PROJECT_NAME}
-	m
 	#	pthread
 	#	hdf5
 	#	hdf5_cpp

--- a/graphicsbezieredge.hpp
+++ b/graphicsbezieredge.hpp
@@ -18,8 +18,9 @@ class GraphicsNodeSocket;
 // TODO: move specific draw stuff out of the graphics-edge
 //       this may actually lead to the proper data model for a data layer
 
-class GraphicsDirectedEdge : public QGraphicsPathItem
+class GraphicsDirectedEdge : public QObject, public QGraphicsPathItem
 {
+    Q_OBJECT
 public:
 	// GraphicsDirectedEdge(qreal factor=0.5f);
 	explicit GraphicsDirectedEdge(qreal factor=0.5f);
@@ -59,6 +60,9 @@ public:
 
 protected:
 	virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+
+protected slots:
+    void onSourceDataChange(); // cant use QVariant argument, since it might be another type
 
 protected:
 	virtual void update_path() = 0;

--- a/graphicsnode.cpp
+++ b/graphicsnode.cpp
@@ -200,9 +200,9 @@ itemChange(GraphicsItemChange change, const QVariant &value)
 
 
 const GraphicsNodeSocket* GraphicsNode::
-add_sink(const QString &text)
+add_sink(const QString &text,QObject *data,int id)
 {
-	auto s = new GraphicsNodeSocket(GraphicsNodeSocket::SINK, text, this);
+    auto s = new GraphicsNodeSocket(GraphicsNodeSocket::SINK, text, this,data,id);
 	_sinks.push_back(s);
 	_changed = true;
 	prepareGeometryChange();
@@ -212,9 +212,9 @@ add_sink(const QString &text)
 
 
 const GraphicsNodeSocket* GraphicsNode::
-add_source(const QString &text)
+add_source(const QString &text,QObject *data,int id)
 {
-	auto s = new GraphicsNodeSocket(GraphicsNodeSocket::SOURCE, text, this);
+    auto s = new GraphicsNodeSocket(GraphicsNodeSocket::SOURCE, text, this,data,id);
 	_sources.push_back(s);
 	_changed = true;
 	prepareGeometryChange();

--- a/graphicsnode.hpp
+++ b/graphicsnode.hpp
@@ -38,8 +38,8 @@ public:
 			QWidget *widget = 0);
 
 
-	const GraphicsNodeSocket* add_sink(const QString &text);
-	const GraphicsNodeSocket* add_source(const QString &text);
+    const GraphicsNodeSocket* add_sink(const QString &text,QObject *data=0,int id=0);
+    const GraphicsNodeSocket* add_source(const QString &text,QObject *data=0,int id=0);
 
 	GraphicsNodeSocket* get_source_socket(const size_t id);
 	GraphicsNodeSocket* get_sink_socket(const size_t id);

--- a/graphicsnodesocket.cpp
+++ b/graphicsnodesocket.cpp
@@ -37,7 +37,7 @@ GraphicsNodeSocket(GraphicsNodeSocketType type, QGraphicsItem *parent)
 
 
 GraphicsNodeSocket::
-GraphicsNodeSocket(GraphicsNodeSocketType socket_type, const QString &text, QGraphicsItem *parent)
+GraphicsNodeSocket(GraphicsNodeSocketType socket_type, const QString &text, QGraphicsItem *parent, QObject *data,int index)
 : QGraphicsItem(parent)
 , _socket_type(socket_type)
 , _pen_circle(PEN_COLOR_CIRCLE)
@@ -45,6 +45,7 @@ GraphicsNodeSocket(GraphicsNodeSocketType socket_type, const QString &text, QGra
 , _brush_circle((socket_type == SINK) ? BRUSH_COLOR_SINK : BRUSH_COLOR_SOURCE)
 , _text(text)
 , _edge(nullptr)
+,m_data(data),m_index(index)
 {
 	_pen_circle.setWidth(0);
 	setAcceptDrops(true);

--- a/graphicsnodesocket.hpp
+++ b/graphicsnodesocket.hpp
@@ -23,6 +23,7 @@ class GraphicsDirectedEdge;
  */
 class GraphicsNodeSocket : public QGraphicsItem
 {
+    friend class GraphicsDirectedEdge;
 public:
 	/*
 	 * the socket comes in two flavors: either as sink or as source for a
@@ -35,8 +36,8 @@ public:
 	};
 
 
-	GraphicsNodeSocket(GraphicsNodeSocketType socket_type, QGraphicsItem *parent = nullptr);
-	GraphicsNodeSocket(GraphicsNodeSocketType socket_type, const QString &text, QGraphicsItem *parent = nullptr);
+    GraphicsNodeSocket(GraphicsNodeSocketType socket_type, QGraphicsItem *parent = nullptr);
+    GraphicsNodeSocket(GraphicsNodeSocketType socket_type, const QString &text, QGraphicsItem *parent = nullptr,QObject *data=0,int index=0);
 
 	virtual QRectF boundingRect() const override;
 
@@ -111,6 +112,8 @@ private:
 	 * edge with which this socket is connected
 	 */
 	GraphicsDirectedEdge *_edge;
+    QObject* m_data;
+    int m_index;
 
 
 private:// some constants. TODO: need to be defined somewhere else (customizable?)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -114,13 +114,29 @@ addNodeViews()
 	}
     */
 
-    QObject* t1 = new testnode1();
-    auto n = new qObjectnode(t1);
-    _scene->addItem(n);
+
+    QObject* t1 = new QLineEdit();
+    qObjectnode* n1 = new qObjectnode(t1);
+    _scene->addItem(n1);
+    n1->setPos(0,0);
+
+    t1 = new testnode1();
+    qObjectnode* n2 = new qObjectnode(t1);
+    _scene->addItem(n2);
+    n2->setPos(0+n1->width()*1.5,0);
+
+
+    GraphicsDirectedEdge* e12 = new GraphicsBezierEdge();
+    e12->connect(n1,0,n2,0);
+    _scene->addItem(e12);
 
     t1 = new QLineEdit();
-    n = new qObjectnode(t1);
-    _scene->addItem(n);
+    qObjectnode* n3 = new qObjectnode(t1);
+    _scene->addItem(n3);
+    n3->setPos(n2->pos().x()+n2->width()*1.5,0);
 
+    GraphicsDirectedEdge* e23 = new GraphicsBezierEdge();
+    e23->connect(n2,0,n3,0);
+    _scene->addItem(e23);
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -17,6 +17,7 @@
 #include <QResizeEvent>
 #include <QButtonGroup>
 #include <QString>
+#include <QLineEdit>
 
 #include <iostream>
 
@@ -25,6 +26,9 @@
 #include "graphicsnodeview.hpp"
 #include "graphicsnode.hpp"
 #include "graphicsbezieredge.hpp"
+
+#include "qobjectnode.hpp"
+#include "test_qobjects.hpp"
 
 
 MainWindow::MainWindow()
@@ -90,6 +94,7 @@ addFakeContent()
 void MainWindow::
 addNodeViews()
 {
+    /*
 	for (int i = 0; i < 5; i++) {
 		auto n = new GraphicsNode();
 		for (int j = i; j < 5; j++) {
@@ -107,5 +112,15 @@ addNodeViews()
 
 		_scene->addItem(n);
 	}
+    */
+
+    QObject* t1 = new testnode1();
+    auto n = new qObjectnode(t1);
+    _scene->addItem(n);
+
+    t1 = new QLineEdit();
+    n = new qObjectnode(t1);
+    _scene->addItem(n);
+
 }
 

--- a/qobjectnode.cpp
+++ b/qobjectnode.cpp
@@ -1,0 +1,30 @@
+#include "qobjectnode.hpp"
+#include <QMetaProperty>
+#include <QWidget>
+
+qObjectnode::qObjectnode(QObject *data, QGraphicsItem *parent):GraphicsNode(parent)
+{
+    m_data=data;
+    if(m_data==0)
+        qWarning("NULL Data Object!");
+    else
+    {
+        QWidget* tst = dynamic_cast<QWidget*>(data);
+        if(tst!=0)
+            setCentralWidget(tst);
+
+        const QMetaObject* m = m_data->metaObject();
+        int property_count = m->propertyCount()-1;
+
+        for(;property_count>=0;property_count--)
+        {
+            QMetaProperty prop = m->property(property_count);
+            if(prop.isConstant() || !prop.isUser())
+                continue;
+            if(prop.isReadable() && prop.hasNotifySignal())
+                add_source(prop.name());
+            if(prop.isWritable())
+                add_sink(prop.name());
+        }
+    }
+}

--- a/qobjectnode.cpp
+++ b/qobjectnode.cpp
@@ -22,9 +22,11 @@ qObjectnode::qObjectnode(QObject *data, QGraphicsItem *parent):GraphicsNode(pare
             if(prop.isConstant() || !prop.isUser())
                 continue;
             if(prop.isReadable() && prop.hasNotifySignal())
-                add_source(prop.name());
+            {
+                add_source(QString(prop.name()) + "[" +QString(prop.typeName())  +"]",m_data,property_count);
+            }
             if(prop.isWritable())
-                add_sink(prop.name());
+                add_sink(QString(prop.name()) + "[" +QString(prop.typeName())  +"]",m_data,property_count);
         }
     }
 }

--- a/qobjectnode.hpp
+++ b/qobjectnode.hpp
@@ -1,0 +1,10 @@
+#include "graphicsnode.hpp"
+
+class qObjectnode: public GraphicsNode
+{
+public:
+    qObjectnode(QObject* data, QGraphicsItem *parent = nullptr);
+
+private:
+    QObject* m_data;
+};

--- a/test_qobjects.cpp
+++ b/test_qobjects.cpp
@@ -1,0 +1,15 @@
+#include "test_qobjects.hpp"
+
+QString testnode1::getTXT() const
+{
+    return m_txt;
+}
+
+void testnode1::setTXT(QString arg)
+{
+    if (m_txt == arg)
+        return;
+
+    m_txt = arg;
+    emit txtChanged(arg);
+}

--- a/test_qobjects.hpp
+++ b/test_qobjects.hpp
@@ -1,0 +1,15 @@
+#include <qobject.h>
+
+class testnode1: public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString txt READ getTXT WRITE setTXT NOTIFY txtChanged USER true)
+public:
+    QString getTXT() const;
+public slots:
+    void setTXT(QString arg);
+signals:
+    void txtChanged(QString arg);
+private:
+    QString m_txt;
+};


### PR DESCRIPTION
I found your project when searching for a way to re arange functions for testing purpose.
(Change input output flow)

So my suggestion (see request), is to create nodes were the propertys are connectef by the node-editor.

It is a quick-hacked solution and does not take the widget/modell seperation mentionet in the to-fos.
