### PR TITLE
Support removing nodes, edges and (mostly) sockets

### DIFF
--- a/src/graphicsbezieredge.cpp
+++ b/src/graphicsbezieredge.cpp
@@ -130,7 +130,7 @@ updatePath()
         .data(Qt::SizeHintRole);
 
     // compute anchor point offsets
-    const qreal min_dist = 0.f; //FIXME this is dead code? can the code below ever get negative?
+    const qreal min_dist = 0.; //FIXME this is dead code? can the code below ever get negative?
 
     QPointF c1 = srcI.canConvert<QPointF>() ? srcI.toPointF() : d_ptr->_start;
 

--- a/src/graphicsbezieredge.hpp
+++ b/src/graphicsbezieredge.hpp
@@ -36,7 +36,7 @@ public:
 
 protected:
     // It cannot be constructed by itself or the user
-    explicit GraphicsDirectedEdge(QNodeEditorEdgeModel* m, const QModelIndex& index, qreal factor=0.5f);
+    explicit GraphicsDirectedEdge(QNodeEditorEdgeModel* m, const QModelIndex& index, qreal factor=0.5);
 
     GraphicsDirectedEdgePrivate* d_ptr;
     Q_DECLARE_PRIVATE(GraphicsDirectedEdge)
@@ -48,7 +48,7 @@ class GraphicsBezierEdge : public GraphicsDirectedEdge
 public:
 
 protected:
-    explicit GraphicsBezierEdge(QNodeEditorEdgeModel* m, const QModelIndex& index, qreal factor=0.5f);
+    explicit GraphicsBezierEdge(QNodeEditorEdgeModel* m, const QModelIndex& index, qreal factor=0.5);
 };
 
 #endif /* GRAPHICS_DIRECTED_EDGE_H */

--- a/src/graphicsnode.cpp
+++ b/src/graphicsnode.cpp
@@ -84,6 +84,12 @@ public:
 // Necessary for some compilers...
 constexpr const qreal GraphicsNodePrivate::_hard_min_width;
 constexpr const qreal GraphicsNodePrivate::_hard_min_height;
+constexpr const qreal GraphicsNodePrivate::_top_margin;
+constexpr const qreal GraphicsNodePrivate::_bottom_margin;
+constexpr const qreal GraphicsNodePrivate::_item_padding;
+constexpr const qreal GraphicsNodePrivate::_lr_padding;
+constexpr const qreal GraphicsNodePrivate::_pen_width;
+constexpr const qreal GraphicsNodePrivate::_socket_size;
 
 
 GraphicsNode::GraphicsNode(QNodeEditorSocketModel* model, const QPersistentModelIndex& index, QGraphicsItem *parent)
@@ -271,6 +277,8 @@ setSize(const QSizeF size)
 QVariant NodeGraphicsItem::
 itemChange(GraphicsItemChange change, const QVariant &value)
 {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wswitch"
     switch (change) {
     case QGraphicsItem::ItemSelectedChange:
         setZValue(value.toBool() ? 1 : 0);
@@ -286,7 +294,7 @@ itemChange(GraphicsItemChange change, const QVariant &value)
     default:
         break;
     }
-
+    #pragma GCC diagnostic pop
     return QGraphicsItem::itemChange(change, value);
 }
 

--- a/src/graphicsnode.hpp
+++ b/src/graphicsnode.hpp
@@ -32,6 +32,7 @@ public:
     QGraphicsItem *graphicsItem() const;
 
     QSizeF size() const;
+    QRectF rect() const;
 
     void setTitle(const QString &title);
 
@@ -59,6 +60,7 @@ private:
     virtual ~GraphicsNode();
 
     void update();
+    void setIndex(const QModelIndex& idx);//FIXME HACK this is a workaround for a bug elsewhere
 
     GraphicsNodePrivate* d_ptr;
     Q_DECLARE_PRIVATE(GraphicsNode)

--- a/src/graphicsnode.hpp
+++ b/src/graphicsnode.hpp
@@ -21,7 +21,7 @@ class QNodeEditorSocketModel;
 
 class GraphicsNodePrivate;
 
-class GraphicsNode : public QObject
+class Q_DECL_EXPORT GraphicsNode : public QObject
 {
     friend class QNodeEditorSocketModel; // To update them
     friend class QNodeEditorSocketModelPrivate; // For creating GraphicsNodes

--- a/src/graphicsnodesocket.cpp
+++ b/src/graphicsnodesocket.cpp
@@ -23,8 +23,6 @@
 
 #define BRUSH_COLOR_SINK      QColor("#FF0077FF")
 #define BRUSH_COLOR_SOURCE    QColor("#FFFF7700")
-#define TEXT_ALIGNMENT_SINK   Qt::AlignLeft
-#define TEXT_ALIGNMENT_SOURCE Qt::AlignRight
 
 #include "graphicsbezieredge_p.h"
 

--- a/src/graphicsnodeview.cpp
+++ b/src/graphicsnodeview.cpp
@@ -80,6 +80,8 @@ wheelEvent(QWheelEvent *event) {
 void GraphicsNodeView::
 mousePressEvent(QMouseEvent *event)
 {
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wswitch"
 	switch (event->button()) {
 	case Qt::MiddleButton:
 		middleMouseButtonPress(event);
@@ -90,6 +92,7 @@ mousePressEvent(QMouseEvent *event)
 	default:
 		QGraphicsView::mousePressEvent(event);
 	}
+	#pragma GCC diagnostic pop
 }
 
 
@@ -144,6 +147,8 @@ mouseReleaseEvent(QMouseEvent *event)
 {
 	viewport()->setCursor(Qt::ArrowCursor);
 
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wswitch"
 	switch (event->button()) {
 	case Qt::MiddleButton:
 		middleMouseButtonRelease(event);
@@ -154,6 +159,7 @@ mouseReleaseEvent(QMouseEvent *event)
 	default:
 		QGraphicsView::mouseReleaseEvent(event);
 	}
+	#pragma GCC diagnostic pop
 }
 
 
@@ -236,7 +242,7 @@ leftMouseButtonPress(QMouseEvent *event)
 
 			switch (sock->socketType()) {
 			case GraphicsNodeSocket::SocketType::SINK:
-				if (_drag_event->e = m_pModel->getSinkEdge(sock->edge()))
+				if ((_drag_event->e = m_pModel->getSinkEdge(sock->edge())))
 					_drag_event->mode = EdgeDragEvent::to_sink;
 				else {
 					_drag_event->e = m_pModel->initiateConnectionFromSink(
@@ -247,7 +253,7 @@ leftMouseButtonPress(QMouseEvent *event)
 				_drag_event->e->setSink(sock->index());
 				break;
 			case GraphicsNodeSocket::SocketType::SOURCE:
-				if (_drag_event->e = m_pModel->getSinkEdge(sock->edge()))
+				if ((_drag_event->e = m_pModel->getSinkEdge(sock->edge())))
 					_drag_event->mode = EdgeDragEvent::to_source;
 				else {
 					_drag_event->e = m_pModel->initiateConnectionFromSource(

--- a/src/qmodeldatalistdecoder.cpp
+++ b/src/qmodeldatalistdecoder.cpp
@@ -26,6 +26,10 @@ public:
     QHash<QPair<int, int>, QMap<int, QLousyVariantDecoder> > m_Data;
 };
 
+QDebug operator<<(QDebug debug, const QLousyVariantDecoder &v);
+QDataStream &operator<<(QDataStream &s, const QLousyVariantDecoder &self);
+QDataStream &operator>>(QDataStream &s, QLousyVariantDecoder &self);
+
 QDebug operator<<(QDebug debug, const QLousyVariantDecoder &v)
 {
     return debug << QStringLiteral("<<<")

--- a/src/qmultimodeltree.cpp
+++ b/src/qmultimodeltree.cpp
@@ -217,7 +217,8 @@ void QMultiModelTreePrivate::slotAddRows(const QModelIndex& parent, int first, i
             src,
             p,
             {},
-            QStringLiteral("N/A")
+            QStringLiteral("N/A"),
+            {}
         };
     }
     q_ptr->endInsertRows();
@@ -309,7 +310,7 @@ QMimeData* QMultiModelTree::mimeData(const QModelIndexList &indexes) const
         }
     }
 
-    if ((!newList.isEmpty()) && srcModel)
+    if (singleModel && (!newList.isEmpty()) && srcModel)
         return srcModel->mimeData(newList);
 
     return QAbstractItemModel::mimeData(indexes);

--- a/src/qmultimodeltree.h
+++ b/src/qmultimodeltree.h
@@ -39,6 +39,7 @@ public:
     virtual bool dropMimeData(const QMimeData *data, Qt::DropAction action,
                 int row, int column, const QModelIndex &parent) override;
     virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    virtual bool removeRows(int row, int count, const QModelIndex &parent = {}) override;
 
     QModelIndex appendModel(QAbstractItemModel* model, const QVariant& id = {});
 

--- a/src/qnodeeditorsocketmodel.cpp
+++ b/src/qnodeeditorsocketmodel.cpp
@@ -52,7 +52,7 @@ struct NodeWrapper final
     QRectF m_SceneRect;
 };
 
-struct SocketWrapper
+struct SocketWrapper final
 {
     SocketWrapper(const QModelIndex& idx, GraphicsNodeSocket::SocketType t, NodeWrapper* n)
         : m_Socket(idx, t, &n->m_Node), m_pNode(n) {}
@@ -692,8 +692,6 @@ QVariant QNodeEditorEdgeModel::data(const QModelIndex& idx, int role) const
             ).toModelIndex();
 
             return d_ptr->q_ptr->mapFromSource(srcIdx).data(Qt::BackgroundRole);
-
-            break;
     }
 
     auto sock = (!idx.column()) ?
@@ -833,9 +831,11 @@ QModelIndex QNodeEdgeFilterProxy::mapFromSource(const QModelIndex& srcIdx) const
         case GraphicsNodeSocket::SocketType::SOURCE:
             if (check(m_pWrapper->m_lSourcesFromSrc, srcIdx, &m_pWrapper->m_Node))
                 return createIndex(m_pWrapper->m_lSourcesFromSrc[srcIdx.row()] - 1, 0, Q_NULLPTR);
+            break;
         case GraphicsNodeSocket::SocketType::SINK:
             if (check(m_pWrapper->m_lSinksFromSrc, srcIdx, &m_pWrapper->m_Node))
                 return createIndex(m_pWrapper->m_lSinksFromSrc[srcIdx.row()] - 1, 0, Q_NULLPTR);
+            break;
     }
 
     return {};

--- a/src/qnodeview.h
+++ b/src/qnodeview.h
@@ -11,7 +11,7 @@ class GraphicsNode;
 
 //TODO use  a QAbstractItemView as the base class...
 
-class QNodeView : public GraphicsNodeView
+class Q_DECL_EXPORT QNodeView : public GraphicsNodeView
 {
     Q_OBJECT
 public:

--- a/src/qnodewidget.h
+++ b/src/qnodewidget.h
@@ -9,7 +9,7 @@ class QNodeWidgetPrivate;
 class QAbstractItemModel;
 class GraphicsNode;
 
-class QNodeWidget : public QNodeView
+class Q_DECL_EXPORT QNodeWidget : public QNodeView
 {
     Q_OBJECT
 public:
@@ -43,5 +43,5 @@ public:
 
 private:
     QNodeWidgetPrivate* d_ptr;
-    Q_DECLARE_PRIVATE(QNodeWidget);
+    Q_DECLARE_PRIVATE(QNodeWidget)
 };

--- a/src/qobjectmodel.cpp
+++ b/src/qobjectmodel.cpp
@@ -164,12 +164,15 @@ QVariant QObjectModel::data(const QModelIndex& idx, int role) const
 
 bool QObjectModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
-    if (!index.isValid()) return false;
+    Q_UNUSED(role)
+    if (!index.isValid())
+        return false;
 
     const auto item = static_cast<InternalItem*>(index.internalPointer());
 
     if (!value.canConvert(item->m_pProp->metaType))
         return false;
+
 
     item->m_pObject->setProperty(item->m_pProp->name, value);
     return true;
@@ -223,12 +226,16 @@ Qt::ItemFlags QObjectModel::flags(const QModelIndex &idx) const
 
 QModelIndex QObjectModel::parent(const QModelIndex& idx) const
 {
+    Q_UNUSED(idx)
     // This model doesn't support trees yet
     return {};
 }
 
 QVariant QObjectModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
+    Q_UNUSED(section)
+    Q_UNUSED(orientation)
+    Q_UNUSED(role)
     return {};
 }
 
@@ -245,7 +252,7 @@ void QObjectModel::setHeterogeneous(bool value)
     d_ptr->regen();
 }
 
-Qt::Orientation QObjectModel::oridentation() const
+Qt::Orientation QObjectModel::orientation() const
 {
     return d_ptr->m_IsVertical ? Qt::Vertical : Qt::Horizontal;
 }
@@ -273,7 +280,7 @@ bool QObjectModel::isReadOnly() const
 
 void QObjectModel::setReadOnly(bool value)
 {
-    const bool changed = value != d_ptr->m_IsReadOnly;
+    //const bool changed = value != d_ptr->m_IsReadOnly;
     d_ptr->m_IsReadOnly = value;
 
     // Emit dataChanged so the ::flags() method is called by the view
@@ -324,7 +331,7 @@ void QObjectModel::addObject(QObject* obj)
         // could be done using a custom qt_static_metacall, but again, it is a
         // little pointless to implement.
         if (p->sigIdx >= 0)
-            auto r = new PropertyChangeReceiver(this, ip, obj, p->sigIdx);
+            new PropertyChangeReceiver(this, ip, obj, p->sigIdx);
     }
     endInsertRows();
 }

--- a/src/qobjectmodel.h
+++ b/src/qobjectmodel.h
@@ -22,7 +22,7 @@ class QObjectModelPrivate;
  *
  * It also supports introspection filters to control the content of the model
  */
-class QObjectModel : public QAbstractItemModel
+class Q_DECL_EXPORT QObjectModel : public QAbstractItemModel
 {
     Q_OBJECT
     friend class PropertyChangeReceiver; // for createIndex()
@@ -77,7 +77,7 @@ public:
     void setDisplayRole(int role);
 
     /// Display as a list or a table
-    Qt::Orientation oridentation() const;
+    Qt::Orientation orientation() const;
     void setOrientation(Qt::Orientation o);
 
     /**

--- a/src/qreactiveproxymodel.h
+++ b/src/qreactiveproxymodel.h
@@ -18,7 +18,7 @@ class QReactiveProxyModelPrivate;
  * 
  * All connections has to be from the same model. This could be fixed later.
  */
-class QReactiveProxyModel : public QIdentityProxyModel
+class Q_DECL_EXPORT QReactiveProxyModel : public QIdentityProxyModel
 {
     Q_OBJECT
 public:

--- a/src/qtypecoloriserproxy.h
+++ b/src/qtypecoloriserproxy.h
@@ -7,7 +7,7 @@ class QTypeColoriserProxyPrivate;
 /**
  * Set the background and foreground color based on a role QMetaType.
  */
-class QTypeColoriserProxy : public QIdentityProxyModel
+class Q_DECL_EXPORT QTypeColoriserProxy : public QIdentityProxyModel
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
There is not an `[X]` button. I guess there should eventually a way to turn it off, but for now it will just fail if the model doesn't support `::removeRow`

Also fix a bunch of warnings and add a few more asserts (the proxy chain is so long minor issues cascade very, very fast).