### PR TITLE
Handle memory ownership

### DIFF
--- a/src/qmultimodeltree.cpp
+++ b/src/qmultimodeltree.cpp
@@ -67,6 +67,24 @@ QMultiModelTree::~QMultiModelTree()
     delete d_ptr;
 }
 
+QAbstractItemModel* QMultiModelTree::getModel(const QModelIndex& _idx) const
+{
+    auto idx = _idx;
+
+    if (idx.parent().isValid())
+        idx = idx.parent();
+
+    if ((!idx.isValid()) || idx.model() != this || idx.parent().isValid())
+        return Q_NULLPTR;
+
+    const auto i = static_cast<InternalItem*>(idx.internalPointer());
+
+    Q_ASSERT(!i->m_pParent);
+    Q_ASSERT(i->m_pModel);
+
+    return i->m_pModel;
+}
+
 QVariant QMultiModelTree::data(const QModelIndex& idx, int role) const
 {
     if (!idx.isValid())

--- a/src/qmultimodeltree.cpp
+++ b/src/qmultimodeltree.cpp
@@ -45,6 +45,7 @@ public:
 
 public Q_SLOTS:
     void slotRowsInserted(const QModelIndex& parent, int first, int last);
+    void slotDataChanged(const QModelIndex& tl, const QModelIndex& br);
     void slotAddRows(const QModelIndex& parent, int first, int last, QAbstractItemModel* src);
 };
 
@@ -178,7 +179,6 @@ QModelIndex QMultiModelTree::mapFromSource(const QModelIndex& sourceIndex) const
     if ((!sourceIndex.isValid()) || sourceIndex.parent().isValid() || sourceIndex.column())
         return {};
 
-
     const auto i = d_ptr->m_hModels[sourceIndex.model()];
 
     if ((!i) || sourceIndex.row() >= i->m_lChildren.size())
@@ -236,8 +236,6 @@ bool QMultiModelTree::removeRows(int row, int count, const QModelIndex &parent)
 
         endRemoveRows();
 
-        //Q_EMIT dataChanged(index(0, 0), index(rowCount()-1, columnCount() -1));
-
         return true;
     }
 
@@ -276,6 +274,20 @@ void QMultiModelTreePrivate::slotRowsInserted(const QModelIndex& parent, int fir
     slotAddRows(parent, first, last, model);
 }
 
+void QMultiModelTreePrivate::slotDataChanged(const QModelIndex& tl, const QModelIndex& br)
+{
+    if (tl == br && !tl.parent().isValid()) {
+        const auto i = q_ptr->mapFromSource(tl);
+
+        Q_ASSERT((!tl.isValid()) || i.isValid());
+
+        Q_EMIT q_ptr->dataChanged(i, i);
+    }
+    else {
+        Q_EMIT q_ptr->dataChanged(q_ptr->mapFromSource(tl), q_ptr->mapFromSource(br));
+    }
+}
+
 QModelIndex QMultiModelTree::appendModel(QAbstractItemModel* model, const QVariant& id)
 {
     if ((!model) || d_ptr->m_hModels[model]) return {};
@@ -298,6 +310,8 @@ QModelIndex QMultiModelTree::appendModel(QAbstractItemModel* model, const QVaria
     //TODO connect to the model row moved/removed/reset
     connect(model, &QAbstractItemModel::rowsInserted,
         d_ptr, &QMultiModelTreePrivate::slotRowsInserted);
+    connect(model, &QAbstractItemModel::dataChanged,
+        d_ptr, &QMultiModelTreePrivate::slotDataChanged);
 
     return index(rowCount()-1, 0);
 }

--- a/src/qmultimodeltree.h
+++ b/src/qmultimodeltree.h
@@ -25,6 +25,8 @@ public:
     int topLevelIdentifierRole() const;
     void setTopLevelIdentifierRole(int role);
 
+    Q_INVOKABLE QAbstractItemModel* getModel(const QModelIndex& idx) const;
+
     virtual QVariant data(const QModelIndex& idx, int role) const override;
     virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     virtual int rowCount(const QModelIndex& parent = {}) const override;

--- a/src/qnodewidget.cpp
+++ b/src/qnodewidget.cpp
@@ -13,6 +13,11 @@ public:
     explicit QNodeWidgetPrivate(QObject* p) : QObject(p) {}
 
     QMultiModelTree m_Model{this};
+
+    QNodeWidget* q_ptr;
+
+public Q_SLOTS:
+    void slotRemoveRows(const QModelIndex& parent, int first, int last);
 };
 
 QNodeWidget::QNodeWidget(QWidget* parent) : QNodeView(parent),
@@ -21,6 +26,9 @@ QNodeWidget::QNodeWidget(QWidget* parent) : QNodeView(parent),
     d_ptr->m_Model.setTopLevelIdentifierRole(Qt::UserRole);
 
     setModel(&d_ptr->m_Model);
+
+    connect(reactiveModel(), &QAbstractItemModel::rowsAboutToBeRemoved,
+        d_ptr, &QNodeWidgetPrivate::slotRemoveRows);
 }
 
 QNodeWidget::~QNodeWidget()
@@ -31,6 +39,7 @@ QNodeWidget::~QNodeWidget()
 GraphicsNode* QNodeWidget::addObject(QObject* o, const QString& title, QNodeWidget::ObjectFlags f, const QVariant& uid)
 {
     Q_UNUSED(f)
+    d_ptr->q_ptr = this;
 
     auto m = new QObjectModel({o}, Qt::Vertical, QObjectModel::Role::PropertyNameRole, this);
 
@@ -75,4 +84,27 @@ GraphicsNode* QNodeWidget::addModel(QAbstractItemModel* m, const QString& title,
     Q_ASSERT(getNode(idx));
 
     return getNode(idx);
+}
+
+void QNodeWidgetPrivate::slotRemoveRows(const QModelIndex& parent, int first, int last)
+{
+    if (parent.isValid())
+        return;
+
+    for (int i = first; i <= last; i++) {
+        auto idx = m_Model.index(i, 0);
+
+        Q_ASSERT(idx.isValid());
+
+        auto m = m_Model.getModel(idx);
+
+        if (auto qom = qobject_cast<QObjectModel*>(m)) {
+            if (qom->objectCount() == 1)
+                Q_EMIT q_ptr->objectRemoved(qom->getObject(qom->index(0,0)));
+            else
+                Q_EMIT q_ptr->modelRemoved(m);
+        }
+        else
+            Q_EMIT q_ptr->modelRemoved(m);
+    }
 }

--- a/src/qnodewidget.h
+++ b/src/qnodewidget.h
@@ -41,6 +41,10 @@ public:
         const QVariant&     uid   = {}
     );
 
+Q_SIGNALS:
+    void objectRemoved(QObject* o);
+    void modelRemoved(QAbstractItemModel* m);
+
 private:
     QNodeWidgetPrivate* d_ptr;
     Q_DECLARE_PRIVATE(QNodeWidget)

--- a/src/qobjectmodel.cpp
+++ b/src/qobjectmodel.cpp
@@ -348,6 +348,16 @@ void QObjectModel::addObjects(const QList<QObject*>& objs)
         addObject(o);
 }
 
+QObject* QObjectModel::getObject(const QModelIndex& idx) const
+{
+    if ((!idx.isValid()) || idx.model() != this)
+        return Q_NULLPTR;
+
+    const auto item = static_cast<InternalItem*>(idx.internalPointer());
+
+    return item->m_pObject;
+}
+
 int QObjectModel::objectCount() const
 {
     if (d_ptr->m_IsVertical)

--- a/src/qobjectmodel.cpp
+++ b/src/qobjectmodel.cpp
@@ -348,6 +348,14 @@ void QObjectModel::addObjects(const QList<QObject*>& objs)
         addObject(o);
 }
 
+int QObjectModel::objectCount() const
+{
+    if (d_ptr->m_IsVertical)
+        return d_ptr->m_lRows.isEmpty() ? 0 : 1;
+
+    return d_ptr->m_lRows.size();
+}
+
 void QObjectModelPrivate::clear()
 {
     QList<InternalItem*> items;

--- a/src/qobjectmodel.cpp
+++ b/src/qobjectmodel.cpp
@@ -239,7 +239,7 @@ QVariant QObjectModel::headerData(int section, Qt::Orientation orientation, int 
     return {};
 }
 
-bool QObjectModel::heterogeneous() const
+bool QObjectModel::isHeterogeneous() const
 {
     return d_ptr->m_IsHeterogeneous; //TODO
 }

--- a/src/qobjectmodel.h
+++ b/src/qobjectmodel.h
@@ -45,7 +45,25 @@ public:
         TypeNameRole,
     };
 
+    /// Get the number of objects displayed by the model
     Q_PROPERTY(int objectCount READ objectCount)
+
+    /** In heterogeneous mode, this model take all the properties and mix
+     * them. When this is disabled (default), only the common properties are
+     * added to the model (to preserve the table columns consistency)
+     **/
+    Q_PROPERTY(bool heterogeneous READ isHeterogeneous WRITE setHeterogeneous)
+
+    /// By default, the value is used, but it can be configured to use something else
+    Q_PROPERTY(int displayRole READ displayRole WRITE setDisplayRole)
+
+    /// Display as a list or a table
+    Q_PROPERTY(Qt::Orientation orientation READ orientation WRITE setOrientation)
+
+    /**
+     * By default, this models enable "setData" when the property is writable.
+     */
+    Q_PROPERTY(bool readOnly READ isReadOnly WRITE setReadOnly)
 
     explicit QObjectModel(QObject* parent = Q_NULLPTR);
     QObjectModel(const QList<QObject*> objs, Qt::Orientation = Qt::Horizontal, int displayRole = Qt::DisplayRole, QObject* parent = Q_NULLPTR);
@@ -61,38 +79,31 @@ public:
     virtual QModelIndex parent(const QModelIndex& idx) const override;
     virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-    /** In heterogeneous mode, this model take all the properties and mix
-     * them. When this is disabled (default), only the common properties are
-     * added to the model (to preserve the table columns consistency)
-     **/
-    bool heterogeneous() const;
+    bool isHeterogeneous() const;
     void setHeterogeneous(bool value); //TODO
 
-    /**
-     * By default, this models enable "setData" when the property is writable.
-     */
     bool isReadOnly() const; //TODO
     void setReadOnly(bool value);
 
-    /// By default, the value is used, but it can be configured to use something else
     int displayRole() const;
     void setDisplayRole(int role);
 
-    /// Get the number of objects displayed by the model
     int objectCount() const;
 
-    /// Display as a list or a table
     Qt::Orientation orientation() const;
     void setOrientation(Qt::Orientation o);
 
     /**
      * Add objects to be displayed in the model.
      */
-    void addObject(QObject* obj);
-    void addObjects(const QVector<QObject*>& objs);
-    void addObjects(const QList<QObject*>& objs);
+    Q_INVOKABLE void addObject(QObject* obj);
+    Q_INVOKABLE void addObjects(const QVector<QObject*>& objs);
+    Q_INVOKABLE void addObjects(const QList<QObject*>& objs);
 
 private:
     QObjectModelPrivate* d_ptr;
     Q_DECLARE_PRIVATE(QObjectModel)
 };
+
+Q_FLAGS(QObjectModel::Capabilities)
+Q_ENUMS(QObjectModel::Role)

--- a/src/qobjectmodel.h
+++ b/src/qobjectmodel.h
@@ -45,6 +45,8 @@ public:
         TypeNameRole,
     };
 
+    Q_PROPERTY(int objectCount READ objectCount)
+
     explicit QObjectModel(QObject* parent = Q_NULLPTR);
     QObjectModel(const QList<QObject*> objs, Qt::Orientation = Qt::Horizontal, int displayRole = Qt::DisplayRole, QObject* parent = Q_NULLPTR);
     virtual ~QObjectModel();
@@ -75,6 +77,9 @@ public:
     /// By default, the value is used, but it can be configured to use something else
     int displayRole() const;
     void setDisplayRole(int role);
+
+    /// Get the number of objects displayed by the model
+    int objectCount() const;
 
     /// Display as a list or a table
     Qt::Orientation orientation() const;

--- a/src/qobjectmodel.h
+++ b/src/qobjectmodel.h
@@ -90,6 +90,8 @@ public:
 
     int objectCount() const;
 
+    Q_INVOKABLE QObject* getObject(const QModelIndex& idx) const;
+
     Qt::Orientation orientation() const;
     void setOrientation(Qt::Orientation o);
 


### PR DESCRIPTION
If the NodeWidget is the parent of the QObjects or QAbstractItemModel, then delete them when they're removed. This also adds signals and getters elsewhere to make the code cleaner.

It's all packed into small atomic commits, so it should be trivial to review (no more 6.5k line PRs)