### PR TITLE
Add more of the missing QAbstractItemView features

### DIFF
--- a/src/graphicsbezieredge.cpp
+++ b/src/graphicsbezieredge.cpp
@@ -58,9 +58,11 @@ GraphicsDirectedEdge(QNodeEditorEdgeModel* m, const QModelIndex& index, qreal fa
     d_ptr->_pen.setWidth(2);
     d_ptr->m_pGrpahicsItem->setZValue(-1);
 
+#if 0
     d_ptr->_effect->setBlurRadius(15.0);
     d_ptr->_effect->setColor(QColor("#99050505"));
     d_ptr->m_pGrpahicsItem->setGraphicsEffect(d_ptr->_effect);
+#endif
 }
 
 void GraphicsDirectedEdge::update()
@@ -85,7 +87,9 @@ graphicsItem() const
 GraphicsDirectedEdge::
 ~GraphicsDirectedEdge()
 {
+#if 0
     delete d_ptr->_effect;
+#endif
     delete d_ptr->m_pGrpahicsItem;
     delete d_ptr;
 }

--- a/src/graphicsbezieredge_p.h
+++ b/src/graphicsbezieredge_p.h
@@ -13,7 +13,9 @@ public:
     explicit GraphicsDirectedEdgePrivate(GraphicsDirectedEdge* q) : q_ptr(q) {}
 
     //TODO support effect lazy loading
+#if 0
     QGraphicsDropShadowEffect *_effect {new QGraphicsDropShadowEffect()};
+#endif
 
     QPen _pen {QColor("#00FF00")};
     QPointF _start;

--- a/src/graphicsnode.cpp
+++ b/src/graphicsnode.cpp
@@ -301,7 +301,10 @@ setSize(const QPointF size)
 void GraphicsNode::
 setSize(const QSizeF size)
 {
-    d_ptr->m_Size = size;
+    d_ptr->m_Size = {
+        std::max(d_ptr->m_MinSize.width() , size.width ()),
+        std::max(d_ptr->m_MinSize.height(), size.height())
+    };
 
     d_ptr->_changed = true;
     d_ptr->m_pGraphicsItem->prepareGeometryChange();
@@ -387,11 +390,6 @@ updateGeometry()
 
     // compute if we have reached the minimum size
     updateSizeHints();
-
-    m_Size = {
-        std::max(m_MinSize.width() , m_Size.width()  ),
-        std::max(m_MinSize.height(), m_Size.height() )
-    };
 
     // close button
     _close_item->setPos(m_Size.width() - _close_item->width(), 0);
@@ -523,6 +521,16 @@ updateSizeHints() {
         std::max(min_width, _hard_min_width  ),
         std::max(min_height, _hard_min_height)
     };
+
+    // prevent the scene from being out of sync
+    if (m_Size.width() < min_width || m_Size.height() < min_height) {
+        m_pGraphicsItem->prepareGeometryChange();
+
+        m_Size = {
+            std::max(min_width , m_Size.width ()),
+            std::max(min_height, m_Size.height())
+        };
+    }
 }
 
 CloseButton::CloseButton(NodeGraphicsItem* parent) : QGraphicsTextItem(parent),

--- a/src/graphicsnode.cpp
+++ b/src/graphicsnode.cpp
@@ -207,10 +207,20 @@ graphicsItem() const
 GraphicsNode::
 ~GraphicsNode()
 {
-    if (d_ptr->_central_proxy) delete d_ptr->_central_proxy;
+    Q_ASSERT(!d_ptr->m_pGraphicsItem->scene());
+    // The widget proxy doesn't own the widget unless specified
+    if (d_ptr->_central_proxy) {
+        delete d_ptr->_central_proxy;
+        d_ptr->_central_proxy = Q_NULLPTR;
+
+        // Even when removed from the scene, the prepareGeometryChange is
+        // required to avoid a crash, don't ask me why
+        setSize(0,0);
+    }
 
     delete d_ptr->_title_item;
     delete d_ptr->_effect;
+    delete d_ptr->m_pGraphicsItem;
     delete d_ptr;
 }
 

--- a/src/graphicsnode.cpp
+++ b/src/graphicsnode.cpp
@@ -412,7 +412,6 @@ updateGeometry()
             const auto size = s->size();
 
             s->graphicsItem()->setPos(0, yposSink + size.height()/2.0);
-            s->d_ptr->update();
             yposSink += size.height() + _item_padding;
 
             s->graphicsItem()->setOpacity(s->index().flags() & Qt::ItemIsEnabled ?
@@ -426,7 +425,6 @@ updateGeometry()
 
             yposSrc -= size.height();
             s->graphicsItem()->setPos(m_Size.width(), yposSrc + size.height()/2.0);
-            s->d_ptr->update();
             yposSrc -= _item_padding;
 
             s->graphicsItem()->setOpacity(s->index().flags() & Qt::ItemIsEnabled ?

--- a/src/graphicsnode.hpp
+++ b/src/graphicsnode.hpp
@@ -47,6 +47,9 @@ public:
     void setSize(const QSizeF size);
     void setSize(const QPointF size);
 
+    void setRect(const qreal x, const qreal y, const qreal width, const qreal height);
+    void setRect(const QRectF size);
+
     QModelIndex index() const;
     QAbstractItemModel* model() const;
 

--- a/src/graphicsnode.hpp
+++ b/src/graphicsnode.hpp
@@ -42,8 +42,12 @@ public:
     QPen foreground() const;
 
     void setBackground(const QBrush& brush);
+    void setBackground(const QString& brush);
     void setForeground(const QPen& pen);
     void setForeground(const QColor& pen);
+    void setForeground(const QString& pen);
+
+    void setDecoration(const QVariant& deco);
 
     Q_INVOKABLE QAbstractItemModel *sinkModel() const;
     Q_INVOKABLE QAbstractItemModel *sourceModel() const;

--- a/src/graphicsnode.hpp
+++ b/src/graphicsnode.hpp
@@ -38,6 +38,13 @@ public:
 
     QString title() const;
 
+    QBrush background() const;
+    QPen foreground() const;
+
+    void setBackground(const QBrush& brush);
+    void setForeground(const QPen& pen);
+    void setForeground(const QColor& pen);
+
     Q_INVOKABLE QAbstractItemModel *sinkModel() const;
     Q_INVOKABLE QAbstractItemModel *sourceModel() const;
 

--- a/src/graphicsnode_p.h
+++ b/src/graphicsnode_p.h
@@ -6,6 +6,7 @@
 class NodeGraphicsItem : public QGraphicsItem
 {
     friend class GraphicsNode; // to access the protected methods
+    friend class GraphicsNodePrivate; // to call prepareUpdate
 public:
     NodeGraphicsItem(QGraphicsItem* parent) : QGraphicsItem(parent) {}
 

--- a/src/graphicsnodescene.cpp
+++ b/src/graphicsnodescene.cpp
@@ -14,24 +14,17 @@ GraphicsNodeScene::GraphicsNodeScene(QObject *parent)
 , _color_background(QColor("#393939"))
 , _color_light(QColor("#2F2F2F"))
 , _color_dark(QColor("#292929"))
-, _color_null(QColor("#212121"))
 , _pen_light(QPen(_color_light))
 , _pen_dark(QPen(_color_dark))
-, _pen_null(QPen(_color_null))
 , _brush_background(_color_background)
 {
 	// initialize default pen settings
-	for (auto p : {&_pen_light, &_pen_dark, &_pen_null}) {
+	for (auto p : {&_pen_light, &_pen_dark}) {
 		p->setWidth(0);
 	}
 
 	// initialize the background
 	setBackgroundBrush(_brush_background);
-
-	// add some text to where zero is
-	auto nulltext = this->addText("(0,0)", QFont("Ubuntu Mono"));
-	nulltext->setPos(0, 0);
-	nulltext->setDefaultTextColor(_color_null);
 }
 
 
@@ -72,19 +65,11 @@ drawBackground(QPainter *painter, const QRectF &rect)
 			lines_dark.push_back(QLine(left, y, right, y));
 	}
 
-	// nullspace lines
-	std::vector<QLine> lines_null;
-	lines_null.push_back(QLine(0, top, 0, bottom));
-	lines_null.push_back(QLine(left, 0, right, 0));
-
 	// draw calls
 	painter->setPen(_pen_light);
 	painter->drawLines(lines_light.data(), lines_light.size());
 
 	painter->setPen(_pen_dark);
 	painter->drawLines(lines_dark.data(), lines_dark.size());
-
-	painter->setPen(_pen_null);
-	painter->drawLines(lines_null.data(), lines_null.size());
 }
 

--- a/src/graphicsnodescene.hpp
+++ b/src/graphicsnodescene.hpp
@@ -21,11 +21,9 @@ private:
 	QColor _color_background;
 	QColor _color_light;
 	QColor _color_dark;
-	QColor _color_null;
 
 	QPen _pen_light;
 	QPen _pen_dark;
-	QPen _pen_null;
 
 	QBrush _brush_background;
 };

--- a/src/graphicsnodesocket.cpp
+++ b/src/graphicsnodesocket.cpp
@@ -147,9 +147,19 @@ drawAlignedText(QPainter *painter)
 
     const QRectF rect(corner, QSizeF(s, s));
 
-    const auto fg = m_PersistentIndex.data(Qt::ForegroundRole);
+    auto fg = m_PersistentIndex.data(Qt::ForegroundRole);
 
-    painter->setPen(fg.canConvert<QPen>() ? qvariant_cast<QPen>(fg) : _pen_text);
+    // Same color as the node
+    if (!fg.isValid())
+        fg = m_PersistentIndex.parent().data(Qt::ForegroundRole);
+
+    if (fg.canConvert<QPen>())
+        painter->setPen(qvariant_cast<QPen>(fg));
+    if (fg.canConvert<QColor>())
+        painter->setPen(qvariant_cast<QColor>(fg));
+    else
+        painter->setPen(_pen_text);
+
     painter->drawText(rect, flags, m_PersistentIndex.data().toString(), 0);
 }
 
@@ -256,12 +266,6 @@ setText(const QString& t)
 {
     if (auto m = const_cast<QAbstractItemModel*>(d_ptr->m_PersistentIndex.model()))
         m->setData(d_ptr->m_PersistentIndex, t, Qt::DisplayRole);
-}
-
-void GraphicsNodeSocketPrivate::update()
-{
-    if (auto m = const_cast<QAbstractItemModel*>(m_PersistentIndex.model()))
-        Q_EMIT m->dataChanged(m_PersistentIndex, m_PersistentIndex);
 }
 
 QModelIndex GraphicsNodeSocket::

--- a/src/graphicsnodesocket_p.h
+++ b/src/graphicsnodesocket_p.h
@@ -25,14 +25,11 @@ public:
     */
     bool isInSocketCircle(const QPointF &p) const; //TODO move to the private class
 
-    void update();
-
     // Attributes
     GraphicsNodeSocket::SocketType _socket_type;
     QPen _pen_circle {PEN_COLOR_CIRCLE};
     const QPen _pen_text {PEN_COLOR_TEXT};
     QBrush _brush_circle;
-    GraphicsNode *_node;
 
     QPersistentModelIndex m_PersistentIndex;
     QPersistentModelIndex m_EdgeIndex;

--- a/src/qmultimodeltree.cpp
+++ b/src/qmultimodeltree.cpp
@@ -120,13 +120,22 @@ bool QMultiModelTree::setData(const QModelIndex &index, const QVariant &value, i
         case InternalItem::Mode::ROOT:
             if (d_ptr->m_HasIdRole && d_ptr->m_IdRole == role) {
                 i->m_UId = value;
+                Q_EMIT dataChanged(index, index);
                 return true;
             }
             switch(role) {
                 case Qt::DisplayRole:
-                case Qt::EditRole:
-                    i->m_Title = value.toString();
+                case Qt::EditRole: {
+                    const auto oldT = i->m_Title;
+                    const auto newT = value.toString();
+                    i->m_Title = newT;
+                    Q_EMIT dataChanged(index, index);
+                    if (newT != oldT) {
+                        Q_EMIT modelRenamed(i->m_pModel, newT, oldT);
+                        Q_EMIT modelRenamed(index, newT, oldT);
+                    }
                     return true;
+                }
             }
             break;
     };

--- a/src/qmultimodeltree.cpp
+++ b/src/qmultimodeltree.cpp
@@ -27,7 +27,7 @@ struct InternalItem
     InternalItem*          m_pParent;
     QVector<InternalItem*> m_lChildren;
     QString                m_Title;
-    QVariant               m_UId;
+    QVariant               m_UId, m_Bg, m_Fg, m_Deco;
 };
 
 class QMultiModelTreePrivate : public QObject
@@ -99,6 +99,12 @@ QVariant QMultiModelTree::data(const QModelIndex& idx, int role) const
         return i->m_UId;
 
     switch (role) {
+        case Qt::BackgroundRole:
+            return i->m_Bg;
+        case Qt::ForegroundRole:
+            return i->m_Fg;
+        case Qt::DecorationRole:
+            return i->m_Deco;
         case Qt::DisplayRole:
             return (!i->m_Title.isEmpty()) ?
                 i->m_Title : i->m_pModel->objectName();
@@ -124,6 +130,18 @@ bool QMultiModelTree::setData(const QModelIndex &index, const QVariant &value, i
                 return true;
             }
             switch(role) {
+                case Qt::BackgroundRole:
+                    i->m_Bg = value;
+                    Q_EMIT dataChanged(index, index);
+                    return true;
+                case Qt::ForegroundRole:
+                    i->m_Fg = value;
+                    Q_EMIT dataChanged(index, index);
+                    return true;
+                case Qt::DecorationRole:
+                    i->m_Deco = value;
+                    Q_EMIT dataChanged(index, index);
+                    return true;
                 case Qt::DisplayRole:
                 case Qt::EditRole: {
                     const auto oldT = i->m_Title;
@@ -136,6 +154,7 @@ bool QMultiModelTree::setData(const QModelIndex &index, const QVariant &value, i
                     }
                     return true;
                 }
+                break;
             }
             break;
     };
@@ -287,7 +306,7 @@ void QMultiModelTreePrivate::slotAddRows(const QModelIndex& parent, int first, i
             p,
             {},
             QStringLiteral("N/A"),
-            {}
+            {}, {}, {}, {}
         };
     }
     q_ptr->endInsertRows();
@@ -327,7 +346,7 @@ QModelIndex QMultiModelTree::appendModel(QAbstractItemModel* model, const QVaria
         Q_NULLPTR,
         {},
         id.canConvert<QString>() ? id.toString() : model->objectName(),
-        id
+        id, {}, {}, {}
     };
     d_ptr->m_lRows << d_ptr->m_hModels[model];
     endInsertRows();

--- a/src/qmultimodeltree.h
+++ b/src/qmultimodeltree.h
@@ -45,6 +45,10 @@ public:
 
     QModelIndex appendModel(QAbstractItemModel* model, const QVariant& id = {});
 
+Q_SIGNALS:
+    void modelRenamed(QAbstractItemModel* model, const QString& newName, const QString& oldName);
+    void modelRenamed(const QModelIndex& idx, const QString& newName, const QString& oldName);
+
 public:
     QMultiModelTreePrivate* d_ptr;
     Q_DECLARE_PRIVATE(QMultiModelTree)

--- a/src/qnodeeditorsocketmodel.cpp
+++ b/src/qnodeeditorsocketmodel.cpp
@@ -823,9 +823,11 @@ void QNodeEditorSocketModelPrivate::slotAboutRemoveItem(const QModelIndex &paren
             slotAboutRemoveItem(idx, 0, q_ptr->rowCount(idx) - 1);
 
             auto nw = m_lWrappers[i];
+            nw->m_Node.setCentralWidget(Q_NULLPTR);
             m_pScene->removeItem(nw->m_Node.graphicsItem());
 
             m_lWrappers.remove(i - (i-first));
+
             delete nw;
         }
     }

--- a/src/qnodeview.cpp
+++ b/src/qnodeview.cpp
@@ -29,7 +29,6 @@ QNodeView::QNodeView(QWidget* parent) : GraphicsNodeView(parent),
 
     m_pModel = d_ptr->m_pFactory; //HACK to remove
 
-    d_ptr->m_Scene.setSceneRect(-9999, -9999, 9999, 9999);
     setScene(&d_ptr->m_Scene);
 }
 

--- a/src/qnodeview.cpp
+++ b/src/qnodeview.cpp
@@ -29,7 +29,7 @@ QNodeView::QNodeView(QWidget* parent) : GraphicsNodeView(parent),
 
     m_pModel = d_ptr->m_pFactory; //HACK to remove
 
-    d_ptr->m_Scene.setSceneRect(-32000, -32000, 64000, 64000);
+    d_ptr->m_Scene.setSceneRect(-9999, -9999, 9999, 9999);
     setScene(&d_ptr->m_Scene);
 }
 

--- a/src/qnodewidget.h
+++ b/src/qnodewidget.h
@@ -42,8 +42,15 @@ public:
     );
 
 Q_SIGNALS:
+    // Removing
     void objectRemoved(QObject* o);
     void modelRemoved(QAbstractItemModel* m);
+
+    // Renaming
+    void objectRenamed(QObject* o, const QString& nameName, const QString& oldName);
+    void modelRenamed(QAbstractItemModel* m, const QString& nameName, const QString& oldName);
+    void nodeRenamed(GraphicsNode* n, const QString& nameName, const QString& oldName);
+    void nodeRenamed(const QString& uid, const QString& nameName, const QString& oldName);
 
 private:
     QNodeWidgetPrivate* d_ptr;

--- a/src/qreactiveproxymodel.h
+++ b/src/qreactiveproxymodel.h
@@ -15,8 +15,25 @@ class QReactiveProxyModelPrivate;
  *
  * This is used to implement reactive programming components such as
  * spreadsheets, pipe and filter or node based editing.
- * 
+ *
  * All connections has to be from the same model. This could be fixed later.
+ *
+ * To avoid poluting stderr with QVariant warnings, this macro can be called
+ * from the .cpp to "mute" warnings instead of `Q_DECLARE_METATYPE`.
+ *
+ *    #ifndef Q_DECLARE_STREAM_METATYPE
+ *    #define Q_DECLARE_STREAM_METATYPE(T) \
+ *        QDataStream &operator<<(QDataStream &s, const T);\
+ *        QDataStream &operator<<(QDataStream &s, const T) { return s; }\
+ *        QDataStream &operator>>(QDataStream &s, const T);\
+ *        QDataStream &operator>>(QDataStream &s, const T) { return s; }\
+ *        static int ___ = ([]()->int{\
+ *            qRegisterMetaType<T>(#T);\
+ *            qRegisterMetaTypeStreamOperators<T>(#T);\
+ *            return 0;\
+ *        })();
+ *    #endif
+ *
  */
 class Q_DECL_EXPORT QReactiveProxyModel : public QIdentityProxyModel
 {

--- a/src/qtypecoloriserproxy.cpp
+++ b/src/qtypecoloriserproxy.cpp
@@ -22,10 +22,18 @@ QVariant QTypeColoriserProxy::data(const QModelIndex& idx, int role) const
         return {};
 
     switch(role) {
-        case Qt::BackgroundRole:
-            return d_ptr->m_lBg[idx.data(d_ptr->m_Role).userType()];
-        case Qt::ForegroundRole:
-            return d_ptr->m_lFg[idx.data(d_ptr->m_Role).userType()];
+        case Qt::BackgroundRole: {
+            const auto t = idx.data(d_ptr->m_Role).userType();
+            if (d_ptr->m_lBg.contains(t))
+                return d_ptr->m_lBg[t];
+        }
+        break;
+        case Qt::ForegroundRole: {
+            const auto t = idx.data(d_ptr->m_Role).userType();
+            if (d_ptr->m_lFg.contains(t))
+                return d_ptr->m_lFg[idx.data(d_ptr->m_Role).userType()];
+        }
+        break;
     };
 
     return QIdentityProxyModel::data(idx, role);


### PR DESCRIPTION

 * Renaming nodes on double click
 * Set the background color/brush
 * Set the foreground color/brush
 * Set the decoration / icon / pixmap
 * some doc

I removed:

 * All shadows. They look good, but have a terrible performace, even with a 3GhZ CPU with OpenGL backed QGraphicsScene. 
